### PR TITLE
add blog post from s2.dev

### DIFF
--- a/feeds.yaml
+++ b/feeds.yaml
@@ -34,6 +34,7 @@ feeds:
   url: https://s2.dev/blog/feed.xml
   posts:
     - guid: https://s2.dev/blog/dst
+    - guid: https://s2.dev/blog/linearizability
 - name: PolarSignals
   url: https://www.polarsignals.com/rss.xml
   posts:


### PR DESCRIPTION
Just published a post that touches on the DST setup and how we're using it as part of linearizability verification